### PR TITLE
Encrypt root volume

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,10 @@ data "aws_ami" "snowflake" {
   }
 }
 
+data "aws_kms_key" "default" {
+  key_id = var.kms_key_id
+}
+
 resource "aws_iam_role" "instance_role" {
   name = "MatillionRole"
 
@@ -134,6 +138,7 @@ resource "aws_instance" "default" {
     volume_type           = var.root_volume_type
     volume_size           = var.root_volume_size
     delete_on_termination = var.root_volume_delete_on_termination
+    kms_key_id            = data.aws_kms_key.default.arn
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -216,6 +216,12 @@ variable "instance_role_policy" {
 POLICY
 }
 
+variable "kms_key_id" {
+  type        = string
+  description = "ID of the KMS key to use to encrypt the EBS volume"
+  default     = "alias/aws/ebs"
+}
+
 variable "key_name" {
   type        = string
   description = "Name of the key pair to use"


### PR DESCRIPTION
Default to using the alias/aws/ebs AWS managed CMK, this can be overridden with a customer managed CMK if required. See https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk for more info about AWS managed CMKs.